### PR TITLE
Permit newlines in the comment body regex

### DIFF
--- a/server/src/token.ts
+++ b/server/src/token.ts
@@ -36,7 +36,7 @@ const NO_OUTPUT_WHITE_TOKEN = false;
 
 let spaceRegex = /^[ \r\n\t\f]+/;
 let processingRegex = /^<\?.*?\?>/;
-let commentRegex = /^<!--.*?-->/;
+let commentRegex = /^<!--.*?-->/s;
 let cdataRegex = /^<!\[CDATA\[.*?\]\]>/;
 let entityRegex = /^<!ENTITY.*?>/;
 let notationRegex = /^<!NOTATION.*?>/;


### PR DESCRIPTION
The document outline would previously fail to display if an SVG file contained a multi-line comment. This commit resolves this by allowing newline characters in the regular expression for comments when identifying tokens in the file.