### PR TITLE
remove utf8 zwsp character

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
                     "title": "Preview Exclude",
                     "description": "Exclude Glob pattern for `Preview All Svg`",
                     "type": "string",
-                    "default": "**​/node_modules/**"
+                    "default": "**/node_modules/**"
                 },
                 "svg.pathDataHighlight": {
                     "description": "Show Grammar Highlight in path data",


### PR DESCRIPTION
Removes a random utf8 "invisible space" character (unicode U+200b) that snuck into the default settings JSON.

![zwidth-space-fix package json - vscode-svg2 - Visual Studio Code](https://github.com/user-attachments/assets/41c4ec7b-4418-460a-9ab5-e30017ecf4fa)

Noticed my editor complaining about an invalid value and figured I should upstream it.

```Line 184 | package.json | 1 zero width space (unicode U+200b) here```

Thanks for your hard work @lishu, have a good one!

(◕‿-)✌